### PR TITLE
Adding cpu-only support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ mopp.egg-info/
 .pickle
 
 ner_train_data.pickle
+
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install .
 For Mac and other Ubuntu installations not having a nvidia GPU, we need to explicitly set a environment variable at time of install.
 ```
 git clone https://github.com/deepklarity/jupyter-text2code.git
-export JUPYTER_TEXT2CODE_MODE = "cpu"
+export JUPYTER_TEXT2CODE_MODE="cpu"
 cd jupyter-text2code
 pip install .
 ```

--- a/README.md
+++ b/README.md
@@ -12,11 +12,21 @@
 
 ## Supported Operating Systems:
 - Ubuntu
-- macOS [(with some extra manual steps)](https://github.com/deepklarity/jupyter-text2code/issues/8#issuecomment-692478839)
+- macOS
 
 ## Jupyter plugin Installation:
+### GPU install
 ```
 git clone https://github.com/deepklarity/jupyter-text2code.git
+cd jupyter-text2code
+pip install .
+```
+
+### CPU-only install
+For Mac and other Ubuntu installations not having a nvidia GPU, we need to explicitly set a environment variable at time of install.
+```
+git clone https://github.com/deepklarity/jupyter-text2code.git
+export JUPYTER_TEXT2CODE_MODE = "cpu"
 cd jupyter-text2code
 pip install .
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![](mopp-demo.gif)
 
 ### Blog post with more details:
-#### [Data analysis made easy: Text2Code for Jupyter notebook](https://towardsdatascience.com/data-analysis-made-easy-text2code-for-jupyter-notebook-5380e89bb493)
+#### [Data analysis made easy: Text2Code for Jupyter notebook](https://towardsdatascience.com/data-analysis-made-easy-text2code-for-jupyter-notebook-5380e89bb493?source=friends_link&sk=2c46fff2c31f7fe59b667350e4596b18)
 
 ### Demo Video:
 #### [Text2Code for Jupyter notebook](https://www.youtube.com/watch?v=3gZ7_9W-TJs)

--- a/mopp/mopp.yaml
+++ b/mopp/mopp.yaml
@@ -1,5 +1,5 @@
 Type: IPython Notebook Extension
-Compatibility: 3.x, 4.x, 5.x
+Compatibility: 3.x, 4.x, 5.x, 6.x
 Main: main.js
 Name: mopp
 Icon: icon.jpg

--- a/mopp/mopp_serverextension/__init__.py
+++ b/mopp/mopp_serverextension/__init__.py
@@ -481,7 +481,7 @@ pd.options.plotting.backend = 'plotly'
 
 print("*"*20)
 print("*"*20)
-print("loading_jupyter_server_extension: mopp. First installs will download universal-sentence-encoder, please wait...")
+print("loading_jupyter_server_extension: jupyter-text2code. First install will download universal-sentence-encoder, please wait...")
 print("*"*20)
 print("*"*20)
 CG = CodeGenerator()
@@ -522,4 +522,4 @@ def load_jupyter_server_extension(nb_server_app):
     host_pattern = '.*$'
     route_pattern = url_path_join(web_app.settings['base_url'], '/mopp')
     web_app.add_handlers(host_pattern, [(route_pattern, MoppHandler)])
-    print("loaded_jupyter_server_extension: mopp")
+    print("loaded_jupyter_server_extension: jupyter-text2code")

--- a/mopp/mopp_serverextension/__init__.py
+++ b/mopp/mopp_serverextension/__init__.py
@@ -13,6 +13,12 @@ from notebook.utils import url_path_join
 import tensorflow_hub as hub
 
 home = os.path.dirname(__file__)
+
+# Explicitly persisting TFHUB_CACHE_DIR
+root = os.path.expanduser("~")
+os.makedirs(os.path.join(root, ".cache", "tfhub_modules"), exist_ok=True)
+os.environ["TFHUB_CACHE_DIR"] = os.path.join(root, ".cache", "tfhub_modules")
+
 SPACY_MODEL_DIR = os.path.join(home, "models/ner")
 FAISS_INDEX_PATH = os.path.join(home, "models/intent_index.idx")
 INTENT_DF_PATH = os.path.join(home, "data/ner_templates.csv")
@@ -473,6 +479,11 @@ pd.options.plotting.backend = 'plotly'
             # Dark theme
             return self._dark_theme(entities, debug=debug)
 
+print("*"*20)
+print("*"*20)
+print("loading_jupyter_server_extension: mopp. First installs will download universal-sentence-encoder, please wait...")
+print("*"*20)
+print("*"*20)
 CG = CodeGenerator()
 
 class MoppHandler(IPythonHandler):
@@ -507,7 +518,6 @@ def load_jupyter_server_extension(nb_server_app):
     Args:
         nb_server_app (NotebookWebApplication): handle to the Notebook webserver instance.
     """
-    print("loading_jupyter_server_extension: mopp")
     web_app = nb_server_app.web_app
     host_pattern = '.*$'
     route_pattern = url_path_join(web_app.settings['base_url'], '/mopp')

--- a/scripts/create_intent_index.py
+++ b/scripts/create_intent_index.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
-
+import os
 import sys
 import pandas as pd
 import numpy as np
@@ -18,6 +18,11 @@ def get_embedding(command):
     command = re.sub('[^A-Za-z0-9 ]+', '', command).lower()
     command_embedding = list(np.array(embed([command])[0]))
     return command_embedding
+
+# Explicitly persisting TFHUB_CACHE_DIR
+root = os.path.expanduser("~")
+os.makedirs(os.path.join(root, ".cache", "tfhub_modules"), exist_ok=True)
+os.environ["TFHUB_CACHE_DIR"] = os.path.join(root, ".cache", "tfhub_modules")
 
 embed = hub.load("https://tfhub.dev/google/universal-sentence-encoder/4")
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,16 @@
 import setuptools
+import atexit
+from setuptools.command.install import install
 import os
 from glob import glob
 
+MODE = os.environ.get("JUPYTER_TEXT2CODE_MODE")
+INSTALL_LIBS = ['numpy<1.19.0', 'tensorflow', 'jupyter', 'jupyter_nbextensions_configurator', 'pandas', 'spacy<3.0.0', 'tensorflow_hub', 'absl-py', 'plotly', 'matplotlib']
+
+if MODE and MODE.lower() == "cpu":
+    INSTALL_LIBS.append("faiss-cpu")
+else:
+    INSTALL_LIBS.append("faiss")
 
 def get_serverextension_files():
     data_files = []
@@ -34,7 +43,7 @@ setuptools.setup(
     license="BSD 3-Clause",
     description="Jupyter server extension to assist with data science EDA",
     packages=setuptools.find_packages(),
-    install_requires=['jupyter', 'jupyter_nbextensions_configurator', 'faiss', 'pandas', 'spacy', 'tensorflow', 'tensorflow_hub', 'absl-py', 'plotly', 'matplotlib'],
+    install_requires=INSTALL_LIBS,
     python_requires='>=3.5',
     classifiers=[
         'Framework :: Jupyter',


### PR DESCRIPTION
- Added support for faiss & faiss-cpu being different libraries to handle seamless installation on cpu-only machines.
- Explicitly set `tensorflow_hub` Universal Sentence Encoder model download directory to make model persist across reboots.